### PR TITLE
Fix the native name of kabyle language

### DIFF
--- a/app/src/main/res/values/cnfg.xml
+++ b/app/src/main/res/values/cnfg.xml
@@ -50,7 +50,7 @@ along with ProtonMail. If not, see https://www.gnu.org/licenses/.
         <item>íslenska</item>
         <item>Italiano</item>
         <item>日本語</item>
-        <item>Izwawen</item>
+        <item>Taqbaylit</item>
         <item>Dutch</item>
         <item>Polski</item>
         <item>Português</item>


### PR DESCRIPTION
The native name of kabyle language is Taqbaylit not Izwawen.